### PR TITLE
ExpressionNames(): return expressions used in template

### DIFF
--- a/uritemplates.go
+++ b/uritemplates.go
@@ -184,6 +184,23 @@ func parseTerm(term string) (result templateTerm, err error) {
 	return result, err
 }
 
+// Names returns the names of all variables within the template.
+func (self *UriTemplate) Names() []string {
+	names := make([]string, 0, len(self.parts))
+
+	for _, p := range self.parts {
+		if len(p.raw) > 0 || len(p.terms) == 0 {
+			continue
+		}
+
+		for _, term := range p.terms {
+			names = append(names, term.name)
+		}
+	}
+
+	return names
+}
+
 // Expand expands a URI template with a set of values to produce a string.
 func (self *UriTemplate) Expand(value interface{}) (string, error) {
 	values, ismap := value.(map[string]interface{})


### PR DESCRIPTION
I've got a project that uses URI templates from external sources, and before expanding, I'd like to ensure all of the prerequisite data is available. So I've added the `ExpressionNames` function to `URITemplate` that will return the list of names referenced by the template.

I may be overlooking a corner case; if there are additional tests needed, or if they should be broken out into their own test instead of just piggybacking on Expand's tests, I'm happy to do that.