### PR TITLE
Add a String() method

### DIFF
--- a/uritemplates.go
+++ b/uritemplates.go
@@ -93,6 +93,10 @@ func Parse(rawtemplate string) (template *UriTemplate, err error) {
 	return template, err
 }
 
+func (t UriTemplate) String() string {
+	return t.raw
+}
+
 type templatePart struct {
 	raw           string
 	terms         []templateTerm


### PR DESCRIPTION
Allows us to get the original template pattern back, too :)