### PR TITLE
Handle explicit nil value

### DIFF
--- a/uritemplates.go
+++ b/uritemplates.go
@@ -235,7 +235,7 @@ func (self *templatePart) expand(buf *bytes.Buffer, values map[string]interface{
 	var firstLen = buf.Len()
 	for _, term := range self.terms {
 		value, exists := values[term.name]
-		if !exists {
+		if !exists || value == nil {
 			continue
 		}
 		if buf.Len() != firstLen {

--- a/uritemplates_test.go
+++ b/uritemplates_test.go
@@ -213,6 +213,13 @@ var expand_tests = []struct {
 		true,
 		[]string{"one"},
 	},
+	{
+		map[string]interface{}{"foo": "bar", "baz": nil},
+		"{foo}/{baz}",
+		"bar/",
+		true,
+		[]string{"foo", "baz"},
+	},
 }
 
 func TestUriTemplate_Expand(t *testing.T) {


### PR DESCRIPTION
Currently this code handles missing keys correctly, but a key that
exists and has been explicitly set to nil causes a panic. This handles
it the same way as a key that doesn't exist.